### PR TITLE
Normalize tag paths

### DIFF
--- a/autoload/unite/sources/tag.vim
+++ b/autoload/unite/sources/tag.vim
@@ -372,7 +372,9 @@ function! s:next(tagdata, line, name)
     endif
 
     let path = filename =~ '^\%(/\|\a\+:[/\\]\)' ?
-                \ filename : cont.basedir . '/' . filename
+                \ filename :
+                \ unite#util#substitute_path_separator(
+                \   fnamemodify(cont.basedir . '/' . filename, ':p:.'))
 
     let abbr = s:truncate(name, g:unite_source_tag_max_name_length, 15, '..')
     if g:unite_source_tag_show_fname


### PR DESCRIPTION
Paths like foo/../bar/x.rb will now appear as bar/x.rb

I store my tags file in my .git dir, so all my file paths appeared like `.git/../app/models/blah`.  What do you think to this?  And what's the regex on the line before for?
