### PR TITLE
bugfix: Tag do not show relative dir correctly.

### DIFF
--- a/autoload/unite/sources/tag.vim
+++ b/autoload/unite/sources/tag.vim
@@ -409,8 +409,8 @@ function! s:next(tagdata, line, name)
     let abbr = s:truncate(name, g:unite_source_tag_max_name_length, 15, '..')
     if g:unite_source_tag_show_fname
         let abbr .= '  '.
-                    \ s:truncate('@'.fnamemodify(path,
-                    \   (a:name ==# 'tag/include' ? ':t' : ':.')),
+                    \ s:truncate('@'.
+                    \   (a:name ==# 'tag/include' ? fnamemodify(path, ':t') : filename),
                     \   g:unite_source_tag_max_fname_length, 10, '..')
     endif
     if g:unite_source_tag_show_location


### PR DESCRIPTION
I think it's a bug.I check the vim function manual, the calling of fnamemodify(, ';.') means the relative filename, but path is already absolute-filename.So the function call always failed to get the relative path. 

 In my case, I generate my tagfile with relative file name which is shorter.But in the result I got the absolute-fullname always. So I do not know when use a auto generate tagfile this bug how to fix.