### PR TITLE
Current buffer filter

### DIFF
--- a/autoload/unite/sources/tag.vim
+++ b/autoload/unite/sources/tag.vim
@@ -269,17 +269,23 @@ endfunction
 
 " filter defined by unite's parameter (e.g. Unite tag:filter)
 function! s:pre_filter(result, args)
-    if !empty(a:args)
-        let arg = a:args[0]
+    if !empty(a:args) | for arg in a:args
+        "let arg = a:args[0]
         if arg !=# ''
-            if arg =~# '/'
+            if arg ==# '%'
+            " Current buffer tags
+                let bufname = (&ft=='unite' ? expand('#:p') : expand('%:p'))
+                call filter(a:result, 'v:val.action__path == bufname')
+            " Pattern matching name
+            elseif arg =~# '/'
                 let pat = arg[1 : ]
                 call filter(a:result, 'v:val.word =~? pat')
+            " Normal matching name
             else
                 call filter(a:result, 'v:val.word == arg')
             endif
         endif
-    endif
+    endfor | endif
     return unite#util#uniq_by(a:result, 'v:val.abbr')
 endfunction
 

--- a/autoload/unite/sources/tag.vim
+++ b/autoload/unite/sources/tag.vim
@@ -276,14 +276,14 @@ function! s:pre_filter(result, args)
                 if arg ==# '%'
                 " Current buffer tags
                     let bufname = (&ft==#'unite' ? bufname(b:unite.prev_bufnr) : expand('%:p'))
-                    call filter(a:result, 'v:val.action__path == bufname')
+                    call filter(a:result, 'v:val.action__path ==# bufname')
                 " Pattern matching name
                 elseif arg =~# '/'
                     let pat = arg[1 : ]
                     call filter(a:result, 'v:val.word =~? pat')
                 " Normal matching name
                 else
-                    call filter(a:result, 'v:val.word == arg')
+                    call filter(a:result, 'v:val.word ==# arg')
                 endif
             endif
         endfor

--- a/autoload/unite/sources/tag.vim
+++ b/autoload/unite/sources/tag.vim
@@ -272,7 +272,7 @@ function! s:pre_filter(result, args)
     if !empty(a:args)
         let arg = a:args[0]
         if arg !=# ''
-            if arg ==# '/'
+            if arg =~# '/'
                 let pat = arg[1 : ]
                 call filter(a:result, 'v:val.word =~? pat')
             else

--- a/autoload/unite/sources/tag.vim
+++ b/autoload/unite/sources/tag.vim
@@ -269,23 +269,25 @@ endfunction
 
 " filter defined by unite's parameter (e.g. Unite tag:filter)
 function! s:pre_filter(result, args)
-    if !empty(a:args) | for arg in a:args
-        "let arg = a:args[0]
-        if arg !=# ''
-            if arg ==# '%'
-            " Current buffer tags
-                let bufname = (&ft=='unite' ? expand('#:p') : expand('%:p'))
-                call filter(a:result, 'v:val.action__path == bufname')
-            " Pattern matching name
-            elseif arg =~# '/'
-                let pat = arg[1 : ]
-                call filter(a:result, 'v:val.word =~? pat')
-            " Normal matching name
-            else
-                call filter(a:result, 'v:val.word == arg')
+    if !empty(a:args)
+        for arg in a:args
+            "let arg = a:args[0]
+            if arg !=# ''
+                if arg ==# '%'
+                " Current buffer tags
+                    let bufname = (&ft==#'unite' ? bufname(b:unite.prev_bufnr) : expand('%:p'))
+                    call filter(a:result, 'v:val.action__path == bufname')
+                " Pattern matching name
+                elseif arg =~# '/'
+                    let pat = arg[1 : ]
+                    call filter(a:result, 'v:val.word =~? pat')
+                " Normal matching name
+                else
+                    call filter(a:result, 'v:val.word == arg')
+                endif
             endif
-        endif
-    endfor | endif
+        endfor
+    endif
     return unite#util#uniq_by(a:result, 'v:val.abbr')
 endfunction
 

--- a/doc/unite-tag.txt
+++ b/doc/unite-tag.txt
@@ -61,7 +61,12 @@ Also, you can filter result using parameter.
 >
 	:Unite tag:text
 <
+Other filters: >
 
+        :Unite tag:%            " Current-buffer
+        :Unite tag:/pattern     " Filter with pattern
+
+<
 This plugin does not block vim because tags' information is aggregated
 asynchronously.
 


### PR DESCRIPTION
This is a kind of partial implementation of this but not quite: https://github.com/tsukkee/unite-tag/issues/34 but it solves my https://github.com/tsukkee/unite-tag/issues/24 .

Therefore 
```viml
:Unite tag:% 
```
Filters tags from current buffer.

Additionnaly, I noticed a mistake that prevented from doing
```viml
:Unite tag:/pattern 
```
So there is this in there as well.

Finnaly I wrapped it all in a for-loop, so this is now ok.
```viml
:Unite tag:%:/pattern      " Search for tags matching /pattern in current buffer
```