### PR TITLE
Ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
I'm using git submodules in my dotfiles, when I open vim, a ctags file gets added to doc/tags. Then, my dotfiles repo says I've got unmodified changes to this repo. It's a small inconvenience, but I imagine someone else has it as well. I would love to have this .gitignore added to the repo.